### PR TITLE
Add VST2 `.fxp` to VST3 `.vstpreset` conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,30 @@
 # vstpreset
 
-A simple python module for reading and writing VST3 preset files. Not sure whether it is actually useful... :)
+A simple python module for reading and writing VST3 preset files.
+Ability to convert older VST preset formats, including VST2, and
+many plugins' more native `.fxp` preset formats.
 
-No documentation, no tests yet. This is beta, use at your own risk.
+Some documentation, no tests yet. This is beta, use at your own risk. But it's already saved lives 🤝.
+
+## fxptovst3
+
+Recurses a directory (or single `.fxp` file) and exports VST3 preset
+files (`.vstpreset`) to an output directory tree (default `/tmp`).
+
+See `python fxptovst3 --help`.
+
+These older `.fxp` style binaries are less compatible, less automatable than
+the slightly more modern VST3 `.vstpreset` file format that play
+better with modern DAW built-ins (verses solely custom plugin GUI browsers, etc.).
+
+As an example, here's a zipped archive of all ~3.3k presets provided
+by the great, free OSS [Surge XT synth](https://surge-synthesizer.github.io/),
+in VST3 `.vstpreset` file format: [surge-xt-vstpresets.7z](https://johnnymarnell.github.io/vst3-presets) on Google Drive.
 
 ## vst2tovst3
 
-This is a simple script that will convert .vstpreset-Files create by the VST2 version of a plugin to 
+This is a simple script (tied heavily to Cubase DAW),
+that will convert .vstpreset-Files create by the VST2 version of a plugin to 
 a .vstpreset for the VST3 version. Some plugin vendors use a different plugin ID for the VST2 and VST3
 versions of the same plugin, and for Cubase those are different plugins. 
 

--- a/fxptovst3.py
+++ b/fxptovst3.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import fxp
+import vstpreset
+import argparse
+import re
+from pathlib import Path
+
+
+def log_fxp_info(fxp_preset):
+    print(f"Plugin ID: {fxp_preset.plugin_id}")
+    print(f"Preset Name: {fxp_preset.name}")
+    print(f"Is Opaque?: {fxp_preset.is_opaque()}")
+    print(f"Is Regular?: {fxp_preset.is_regular()}")
+    print(f"Num Params: {fxp_preset.param_count}")
+    print(f"Params: {fxp_preset.is_regular() and fxp_preset.params}")
+
+    print(re.sub(r"(\n\s+\d+)+", "...", f"Struct Representation: {fxp_preset._struct}"))
+
+    for key in dir(fxp_preset._struct):
+        if not key.startswith("__") and key not in {"content"}:
+            try:
+                print(f"{key}: {fxp_preset._struct[key]}")
+            except Exception as e:
+                pass
+
+    # # --- Save param list for inspection ---
+    param_data = []
+    if fxp_preset.is_regular():
+        for p in fxp_preset.params:
+            param_data.append(
+                {
+                    "id": p.id,
+                    "name": p.name,
+                    "value": p.value,
+                    "value_normalized": p.normalized_value,
+                }
+            )
+    print(f"Enumerated {len(param_data)} params vs count: {fxp_preset.param_count}")
+
+    # --- Save opaque chunk if present ---
+    # if fxp_preset.is_opaque():
+    #     with open(Path(output_path) / f"{Path(input_path).stem}.bin", "wb") as f:
+    #         f.write(fxp_preset.data)
+    #     print(f"Saved opaque chunk to {f.name} ({len(fxp_preset.data)} bytes)")
+    # else:
+    #     print("No opaque chunk found — param-only preset.")
+
+
+def convert(
+    input_path,
+    output_path,
+    class_id=None,
+    chunklist_id="List",
+    chunk_id_default="Comp",
+    header_id="VST3",
+    version=1,
+):
+    fxp_preset = fxp.FXP(input_path)
+    print(f"Loaded FXP file: {input_path}")
+    log_fxp_info(fxp_preset)
+
+    # --- Create VSTPreset and write .vstpreset file ---
+    chunks = None
+    if fxp_preset.is_opaque():
+        chunks = {chunk_id_default: fxp_preset.data}
+
+    vst = vstpreset.VST3Preset(
+        class_id=class_id,
+        chunks=chunks,
+        chunklist_id=chunklist_id,
+        header_id=header_id,
+        version=version,
+    )
+
+    if fxp_preset.is_regular():
+        for p in fxp_preset.params:
+            vst.parameters[p.id] = p.normalized_value
+
+    out = Path(output_path) / f"{Path(input_path).stem}.vstpreset"
+    vst.write_file(out)
+    print(f"Wrote .vstpreset to: {out}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("preset_path", help="Path to the .fxp or .vstpreset file")
+    parser.add_argument(
+        "--out", help="Optional path for output .vstpreset", default="/tmp"
+    )
+    parser.add_argument(
+        "--vst3-preset",
+        help="Path to a sample .vstpreset file to use for defaults (e.g. class_id, version)",
+        default=None,
+    )
+    parser.add_argument(
+        "--class-id", help="Override class_id for the output .vstpreset", default=None
+    )
+    parser.add_argument(
+        "--version",
+        type=int,
+        help="Override version for the output .vstpreset",
+        default=None,
+    )
+    parser.add_argument(
+        "--header", help="Override header_id for the output .vstpreset", default=None
+    )
+    parser.add_argument(
+        "--chunklist-id",
+        help="Override chunklist_id for the output .vstpreset",
+        default=None,
+    )
+    args = parser.parse_args()
+
+    # Defaults
+    class_id = None
+    version = 1
+    header_id = "VST3"
+    chunklist_id = "List"
+
+    # If --vst3-preset is provided, parse it for defaults
+    if args.vst3_preset:
+        sample = vstpreset.parse_vst3preset_file(args.vst3_preset)
+        class_id = sample.class_id
+        version = sample.version
+        header_id = sample.header_id
+        chunklist_id = sample.chunklist_id
+        print(f"Using defaults from {args.vst3_preset}: {sample}")
+
+    # Apply direct overrides if provided
+    if args.class_id:
+        class_id = args.class_id
+    if args.version is not None:
+        version = args.version
+    if args.header:
+        header_id = args.header
+    if args.chunklist_id:
+        chunklist_id = args.chunklist_id
+
+    assert class_id is not None, "class_id is required"
+
+    output_path = Path(args.out)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    convert(
+        args.preset_path,
+        output_path,
+        class_id=class_id,
+        chunklist_id=chunklist_id,
+        header_id=header_id,
+        version=version,
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-construct
-fxp

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+construct
+fxp

--- a/setup.py
+++ b/setup.py
@@ -7,10 +7,10 @@ setup(
     version="0.1.0",
     description="simple module for reading and writing VST3 presets ",
     author="Jan Minor",
-    author_email='39484083+janminor@users.noreply.github.com',
+    author_email="39484083+janminor@users.noreply.github.com",
     url="https://github.com/janminor/python-vstpreset",
     packages=["vstpreset"],
-    classifiers=[  
+    classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "Programming Language :: Python :: 3",
@@ -21,4 +21,8 @@ setup(
         "Programming Language :: Python :: 3 :: Only",
     ],
     python_requires=">=3.7, <4",
+    install_requires=[
+        "fxp>=0.1.0",
+        "construct>=2.10.69",
+    ],
 )


### PR DESCRIPTION
Your wonderful repo saved me, I wish I found it sooner despite a lot of googling... was getting VST C binaries to compile, using their custom python bindings, yet still not enough to get to VST3 -- and (oof) even dabbled with mouse/keyboard recorders...

So, yes, definitely useful! The docs and tooling aren't great for these types of Steinberg shenanigans, so, again, thank you! I don't use Cubase (big on REAPER hacking, some Ableton), but hope to cross paths somehow ✌️